### PR TITLE
chore: bump godot-vim to v1.6.1, vim-core dep to v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "godot-vim"
-version = "1.5.0"
+version = "1.6.1"
 dependencies = [
  "bitflags",
  "compact_str",
@@ -746,7 +746,8 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vim-core"
-version = "0.7.0"
+version = "0.7.1"
+source = "git+https://github.com/hmdfrds/vim-core.git?tag=v0.7.1#b6e9c78dbc82ac5c0b69d06de5b240ea7dcd1762"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -770,6 +771,7 @@ dependencies = [
 [[package]]
 name = "vim-regex"
 version = "0.1.0"
+source = "git+https://github.com/hmdfrds/vim-core.git?tag=v0.7.1#b6e9c78dbc82ac5c0b69d06de5b240ea7dcd1762"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -781,6 +783,7 @@ dependencies = [
 [[package]]
 name = "vim-text"
 version = "0.1.0"
+source = "git+https://github.com/hmdfrds/vim-core.git?tag=v0.7.1#b6e9c78dbc82ac5c0b69d06de5b240ea7dcd1762"
 dependencies = [
  "arrayvec",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "godot-vim"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Vim emulation plugin for the Godot game engine"
 license = "MIT"
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 godot = { git = "https://github.com/godot-rust/gdext", tag = "v0.4.5" }
-vim-core = { git = "https://github.com/hmdfrds/vim-core.git", tag = "v0.7.0" }
+vim-core = { git = "https://github.com/hmdfrds/vim-core.git", tag = "v0.7.1" }
 bitflags = "2"
 unicode-segmentation = "1.10"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_trace"] }

--- a/addons/godot_vim/plugin.cfg
+++ b/addons/godot_vim/plugin.cfg
@@ -2,5 +2,5 @@
 name="GodotVim"
 description="Vim keybindings for Godot's script editor"
 author="hmdfrds"
-version="1.6.0"
+version="1.6.1"
 script="godot_vim.gd"


### PR DESCRIPTION
Pulls in vim-core v0.7.1: the tab-aware smarttab Backspace fix and tab-aware `<<` / insert Ctrl-D outdent for tab-indented lines.

Refs #50